### PR TITLE
Save generated code and mark it valid for 10 mins

### DIFF
--- a/back/src/api.ts
+++ b/back/src/api.ts
@@ -9,13 +9,13 @@ interface Options {
 }
 
 export function setupService(app: Express, { emailVCIssuerInterface, sendVerificationCode }: Options, logger: Logger) {
-  app.post('/requestVerification/:did', bodyParser.json(), (req, res) => {
+  app.post('/requestVerification/:did', bodyParser.json(), async (req, res) => {
     const { did } = req.params
     const { emailAddress } = req.body
 
     logger.info(`Requested verification for email ${emailAddress} with did ${did}`)
 
-    const verificationCode = emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
+    const verificationCode = await emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
 
     sendVerificationCode(emailAddress, verificationCode)
 

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -10,6 +10,7 @@ import rateLimit from 'express-rate-limit'
 import SMTPTransport from 'nodemailer/lib/smtp-transport'
 import { createConnection } from 'typeorm'
 import IssuedEmailVC from './model/entities/issued-vc'
+import DidCode from './model/entities/did-code'
 
 dotenv.config()
 
@@ -82,7 +83,7 @@ async function sendVerificationCode(to: string, text: string) {
 createConnection({
   type: 'sqlite',
   database: 'email-vc-issuer.sqlite',
-  entities: [IssuedEmailVC],
+  entities: [IssuedEmailVC, DidCode],
   logging: false,
   dropSchema: false,
   synchronize: true

--- a/back/src/model/VerificationCodeChecker.ts
+++ b/back/src/model/VerificationCodeChecker.ts
@@ -1,5 +1,5 @@
 import { randomBytes }  from 'crypto'
-import { Repository } from 'typeorm'
+import { getConnection, Repository } from 'typeorm'
 import DidCode from './entities/did-code'
 
 export const CODE_NOT_GENERATED_ERROR_MESSAGE = 'Generate code first'
@@ -9,17 +9,8 @@ export default class VerificationCodeChecker {
 
   async generateCodeFor(did: string) {
     const code = randomBytes(32).toString('hex')
-    const newRecord = new DidCode(did, code)
-
-    return this.repository.findOne({ where: { did} })
-      .then(record => {
-        if (!record) return this.repository.save(newRecord) 
-        
-        record.expirationTime = newRecord.expirationTime
-        record.code = code
-        return this.repository.save(record)
-      })
-      .then(() => code)
+    await this.repository.save(new DidCode(did, code))
+    return code
   }
 
   async getCodeOf(did: string) {

--- a/back/src/model/VerificationCodeChecker.ts
+++ b/back/src/model/VerificationCodeChecker.ts
@@ -1,5 +1,5 @@
 import { randomBytes }  from 'crypto'
-import { getConnection, Repository } from 'typeorm'
+import { Repository } from 'typeorm'
 import DidCode from './entities/did-code'
 
 export const CODE_NOT_GENERATED_ERROR_MESSAGE = 'Generate code first'

--- a/back/src/model/entities/did-code.ts
+++ b/back/src/model/entities/did-code.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, PrimaryColumn } from 'typeorm'
+import { Entity, Column, PrimaryColumn } from 'typeorm'
 
 @Entity()
 export default class DidCode {

--- a/back/src/model/entities/did-code.ts
+++ b/back/src/model/entities/did-code.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm'
+import { Entity, PrimaryGeneratedColumn, Column, PrimaryColumn } from 'typeorm'
 
 @Entity()
 export default class DidCode {
@@ -8,10 +8,7 @@ export default class DidCode {
     this.expirationTime = Date.now() + expiresIn
   }
 
-  @PrimaryGeneratedColumn()
-  id!: number;
-
-  @Column('text')
+  @PrimaryColumn()
   did!: string;
 
   @Column('text')

--- a/back/src/model/entities/did-code.ts
+++ b/back/src/model/entities/did-code.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm'
+
+@Entity()
+export default class DidCode {
+  constructor (did: string, code: string, expiresIn = 600000) { // default expiration 10 min
+    this.did = did
+    this.code = code
+    this.expirationTime = Date.now() + expiresIn
+  }
+
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column('text')
+  did!: string;
+
+  @Column('text')
+  code!: string;
+
+  @Column('integer')
+  expirationTime!: number;
+}

--- a/back/test/model/EmailVCIssuerInterface.test.ts
+++ b/back/test/model/EmailVCIssuerInterface.test.ts
@@ -25,7 +25,7 @@ describe('EmailVCIssuerInterface', function (this: {
   afterAll(() => deleteDatabase(this.dbConnection, database))
 
   test('issues verifiable credential when verification code is signed', async () => {
-    const verificationCode = this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
+    const verificationCode = await this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
 
     const sig = rpcPersonalSign(decorateVerificationCode(verificationCode), privateKey)
 
@@ -38,23 +38,23 @@ describe('EmailVCIssuerInterface', function (this: {
     expect(verifiableCredential.issuer.id).toEqual(issuer.did)
   })
 
-  test('fails on invalid signature', () => {
+  test('fails on invalid signature', async () => {
     expect.assertions(1)
 
-    const verificationCode = this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
+    const verificationCode = await this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
 
     const sig = rpcPersonalSign(decorateVerificationCode(verificationCode), anotherPrivateKey)
 
-    return expect(() => this.emailVCIssuerInterface.verify(did, sig)).toThrowError(INVALID_SIGNATURE_ERROR_MESSAGE)
+    return expect(() => this.emailVCIssuerInterface.verify(did, sig)).rejects.toThrowError(INVALID_SIGNATURE_ERROR_MESSAGE)
   })
 
-  test('fails on invalid verification code', () => {
+  test('fails on invalid verification code', async () => {
     expect.assertions(1)
 
-    this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
+    await this.emailVCIssuerInterface.requestVerificationFor(did, emailAddress)
 
     const sig = rpcPersonalSign(decorateVerificationCode('INVALID VERIFICATION CODE'), privateKey)
 
-    return expect(() => this.emailVCIssuerInterface.verify(did, sig)).toThrowError(INVALID_SIGNATURE_ERROR_MESSAGE)
+    return expect(() => this.emailVCIssuerInterface.verify(did, sig)).rejects.toThrowError(INVALID_SIGNATURE_ERROR_MESSAGE)
   })
 })

--- a/back/test/model/VerificationCodeChecker.test.ts
+++ b/back/test/model/VerificationCodeChecker.test.ts
@@ -1,36 +1,70 @@
 import VerificationCodeChecker, { CODE_NOT_GENERATED_ERROR_MESSAGE } from '../../src/model/VerificationCodeChecker'
 import { did, anotherDid } from '../mocks'
+import MockDate from 'mockdate'
+import DidCode from '../../src/model/entities/did-code'
+import { Connection, Repository } from 'typeorm'
+import { createSqliteConnection, resetDatabase, deleteDatabase } from '../utils'
 
 describe('VerificationCodeChecker', function(this: {
   checker: VerificationCodeChecker
+  dbConnection: Connection
+  repository: Repository<DidCode>
 }) {
-  beforeEach(() => {
-    this.checker = new VerificationCodeChecker()
-  })
-  test('checks the code is correct', () => {
-    const code = this.checker.generateCodeFor(did)
+  const database = './email-vc-issuer-code-checker.test.sqlite'
 
-    expect(this.checker.getCodeOf(did)).toEqual(code)
+  beforeAll(async () => {
+    this.dbConnection = await createSqliteConnection(database)
   })
 
-  test('resets code for the same did', () => {
-    const code = this.checker.generateCodeFor(did)
-    const secondCode = this.checker.generateCodeFor(did)
+  beforeEach(async () => {
+    await resetDatabase(this.dbConnection)
+    this.repository = this.dbConnection.getRepository(DidCode)
+    this.checker = new VerificationCodeChecker(this.repository)
+  })
+
+  afterAll(() => deleteDatabase(this.dbConnection, database))
+
+  test('checks the code is correct', async () => {
+    const code = await this.checker.generateCodeFor(did)
+
+    expect(await this.checker.getCodeOf(did)).toEqual(code)
+  })
+
+  test('resets code for the same did', async () => {
+    const code = await this.checker.generateCodeFor(did)
+    const secondCode = await this.checker.generateCodeFor(did)
 
     expect(code).not.toEqual(secondCode)
-    expect(this.checker.getCodeOf(did)).toEqual(secondCode)
+    expect(await this.checker.getCodeOf(did)).toEqual(secondCode)
   })
 
-  test('sends different codes for the different dids', () => {
-    const code = this.checker.generateCodeFor(did)
-    const anotherCode = this.checker.generateCodeFor(anotherDid)
+  test('sends different codes for the different dids', async () => {
+    const code = await this.checker.generateCodeFor(did)
+    const anotherCode = await this.checker.generateCodeFor(anotherDid)
 
     expect(code).not.toEqual(anotherCode)
-    expect(this.checker.getCodeOf(did)).toEqual(code)
-    expect(this.checker.getCodeOf(anotherDid)).toEqual(anotherCode)
+    expect(await this.checker.getCodeOf(did)).toEqual(code)
+    expect(await this.checker.getCodeOf(anotherDid)).toEqual(anotherCode)
   })
 
-  test('does not answer code when not generated', () => {
-    expect(() => this.checker.getCodeOf(did)).toThrowError(CODE_NOT_GENERATED_ERROR_MESSAGE)
+  test('does not answer code when not generated', async () => {
+    expect(() => this.checker.getCodeOf(did)).rejects.toThrowError(CODE_NOT_GENERATED_ERROR_MESSAGE)
+  })
+
+  test('mark code as invalid after 10 minutes', async () => {
+    const code = await this.checker.generateCodeFor(did)
+
+    expect(await this.checker.getCodeOf(did)).toEqual(code)
+
+    MockDate.set(Date.now() + 600000 + 100)
+    expect(() => this.checker.getCodeOf(did)).rejects.toThrowError(CODE_NOT_GENERATED_ERROR_MESSAGE)
+  })
+
+  test('saves the code in the db', async () => {
+    const code = await this.checker.generateCodeFor(did)
+
+    const record = await this.repository.findOne({ where: { did }})
+
+    expect(record!.code).toEqual(code)
   })
 })

--- a/back/test/utils.ts
+++ b/back/test/utils.ts
@@ -2,6 +2,7 @@ import { ecsign, hashPersonalMessage, toRpcSig } from 'ethereumjs-util'
 import { Connection, createConnection } from 'typeorm'
 import IssuedEmailVC from '../src/model/entities/issued-vc'
 import fs from 'fs'
+import DidCode from '../src/model/entities/did-code'
 
 export const rpcPersonalSign = (msg: string, privateKey: Buffer) => {
   const msgHash = hashPersonalMessage(Buffer.from(msg))
@@ -12,7 +13,7 @@ export const rpcPersonalSign = (msg: string, privateKey: Buffer) => {
 export const createSqliteConnection = (database: string) => createConnection({
   type: 'sqlite',
   database,
-  entities: [IssuedEmailVC],
+  entities: [IssuedEmailVC, DidCode],
   logging: false,
   dropSchema: true,
   synchronize: true


### PR DESCRIPTION
- Add new entity to saves generated codes in the DB
- Make `VerificationCodeChecker` method async
- Remove in memory mapping that was used to save codes