### PR TITLE
Add dotenv to front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 node_modules
-.env
 log/
 coverage/
 *.sqlite

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+.env

--- a/front/.env
+++ b/front/.env
@@ -1,0 +1,1 @@
+REACT_APP_BACK_END_URL=https://email-vc-issuer.staging.rifcomputing.net

--- a/front/package.json
+++ b/front/package.json
@@ -1,7 +1,6 @@
 {
   "name": "front",
   "version": "0.1.0",
-  "homepage": "https://rsksmart.github.io/email-vc-issuer/",
   "private": true,
   "dependencies": {
     "@rsksmart/ipfs-cpinner-client": "^0.1.1-beta.13",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -4,7 +4,7 @@ import WalletConnectProvider from '@walletconnect/web3-provider'
 import DataVaultWebClient, { AuthManager, AsymmetricEncryptionManager, SignerEncryptionManager } from '@rsksmart/ipfs-cpinner-client'
 import Nav from './Nav'
 
-const backUrl = 'https://email-vc-issuer.staging.rifcomputing.net'
+const backUrl = process.env.REACT_APP_BACK_END_URL
 
 declare global {
   interface Window {


### PR DESCRIPTION
- Adds dot env to front-end to easily change the instance in different environments
- Remove homepage used for Github Pages

New PR may
- modify the current .env for production server
- create .en.production that overrides .env for `build` script